### PR TITLE
Added Wildcard Subdomain Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This is great for overriding production services for nodes you might be testing 
 
 For your convenience, any subdomain of a DNS entry known to landrush will resolve to the same IP address as the entry. For example: given `myhost.vagrant.dev -> 1.2.3.4`, both `foo.myhost.vagrant.dev` and `bar.myhost.vagrant.dev` will also resolve to `1.2.3.4`.
 
+**NOTE:** Currently, wildcard subdomains are only supported when using a **vagrant.dev** domain such as `myhost.vagrant.dev`.  
+
 ### Unmatched Queries
 
 Any DNS queries that do not match will be passed through to an upstream DNS server, so this will be able to serve as the one-stop shop for your guests' DNS needs.


### PR DESCRIPTION
As per our conversation in the #vagrant IRC, I've added a note to the README to provide a small amount of clarification for others attempting to use wildcard subdomains with hostnames other than vagrant.dev. I would have updated more, but am still a little unclear as to how the code functions as I am not intimately familiar with Ruby. 
