### PR TITLE
New setting to make the modification of the guests iptables rules optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ If you would like to configure your own upstream servers, add upstream entries t
 
 Linux guests should automatically have their DNS traffic redirected via `iptables` rules to the Landrush DNS server. File an issue if this does not work for you.
 
+If you do not want Landrush to modify your iptables rules on your guests you can turn this feature off like so:
+
+    config.landrush.manage_guests = false
+
 ### Visibility on the Host
 
 If you're on an OS X host, we use a nice trick to unobtrusively add a secondary DNS server only for specific domains.

--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -53,6 +53,10 @@ module Landrush
         global_config.landrush.enabled?
       end
 
+      def manage_guests?
+        global_config.landrush.manage_guests
+      end
+
       def info(msg)
         env[:ui].info "[landrush] #{msg}"
       end

--- a/lib/landrush/action/install_prerequisites.rb
+++ b/lib/landrush/action/install_prerequisites.rb
@@ -5,7 +5,7 @@ module Landrush
 
       def call(env)
         handle_action_stack(env) do
-          install_prerequisites if enabled?
+          install_prerequisites if enabled? and manage_guests?
         end
       end
 

--- a/lib/landrush/action/redirect_dns.rb
+++ b/lib/landrush/action/redirect_dns.rb
@@ -5,7 +5,7 @@ module Landrush
 
       def call(env)
         handle_action_stack(env) do
-          redirect_dns if enabled?
+          redirect_dns if enabled? and manage_guests?
         end
       end
 

--- a/lib/landrush/config.rb
+++ b/lib/landrush/config.rb
@@ -2,10 +2,12 @@ module Landrush
   class Config < Vagrant.plugin('2', :config)
     attr_accessor :hosts
     attr_accessor :upstream_servers
+    attr_accessor :manage_guests
 
     def initialize
       @hosts = {}
       @enabled = false
+      @manage_guests = true
       @default_upstream = [[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]]
       @default_tld = 'vagrant.dev'
       @upstream_servers = @default_upstream


### PR DESCRIPTION
I made this as a workaround for the issues mentioned in #33, #35. I experience the same issues in my environment, but only when landrush modifies the iptables rules on my guests.

This disables the functionality to install the iptables rule that forwards DNS queries from the guests to Landrush. I figured that the iptables rule was not necessary in my case for the following reasons:

First a disclaimer: I use VirtualBox, I don't know how whether this will work with other providers. VirtualBox handles DNS queries from the guests by running a DNS server of its own on 10.0.2.2 which uses the hosts DNS settings as upstream. Guests get configured to use 10.0.2.2 as their DNS server, the DNS queries are forwarded to and resolved by the host. 

Through this mechanism the guests actually use the host to resolve their DNS queries. Therefore as long as the hosts DNS is configured to forward queries for `.vagrant.dev` to Landrush, eg. via `dnsmasq` on Linux (see issue #36), the DNS lookup on the guest works as well.

As I have set up my machine to use `dnsmasq` to forward DNS queries to Landrush, I figured that the iptables rule was unnecessary in my case, and was actually causing unnecessary trouble (#33, #35). Therefore I have made this setting to have the option to disable the functionality that installs the iptables rule.
