### PR TITLE
Handle DNS requests in a case-insensitive way

### DIFF
--- a/lib/landrush/store.rb
+++ b/lib/landrush/store.rb
@@ -36,7 +36,10 @@ module Landrush
 
     def get(key)
       value = current_config[key]
-      redirect = find(value)
+      redirect = nil
+      if value.is_a? String
+        redirect = find(value)
+      end
       if value
         if redirect
           get(redirect)


### PR DESCRIPTION
To meet the standards and let DNS resolvers that use [case randomization](https://developers.google.com/speed/public-dns/docs/security#randomize_case) work correctly with landrush.
