### PR TITLE
option to disable guest dns redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ If you would like to configure your own upstream servers, add upstream entries t
 
 Linux guests should automatically have their DNS traffic redirected via `iptables` rules to the Landrush DNS server. File an issue if this does not work for you.
 
+To disable this functionality:
+
+    config.landrush.guest_redirect_dns = false
+
+You may want to do this if you are already proxying all your DNS requests through your host (e.g. using VirtualBox's natdnshostresolver1 option) and you
+have DNS servers that you can easily set as upstreams in the daemon (e.g. DNS requests that go through the host's VPN connection).
+
 ### Visibility on the Host
 
 If you're on an OS X host, we use a nice trick to unobtrusively add a secondary DNS server only for specific domains.

--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -31,7 +31,7 @@ module Landrush
       def vmware?
         provider == :vmware_fusion
       end
-      
+
       def parallels?
         provider == :parallels
       end
@@ -68,6 +68,10 @@ module Landrush
 
       def enabled?
         config.enabled?
+      end
+
+      def guest_redirect_dns?
+        config.guest_redirect_dns?
       end
 
       def info(msg)

--- a/lib/landrush/action/redirect_dns.rb
+++ b/lib/landrush/action/redirect_dns.rb
@@ -5,7 +5,7 @@ module Landrush
 
       def call(env)
         handle_action_stack(env) do
-          redirect_dns if enabled?
+          redirect_dns if enabled? and guest_redirect_dns?
         end
       end
 
@@ -36,4 +36,3 @@ module Landrush
     end
   end
 end
-

--- a/lib/landrush/config.rb
+++ b/lib/landrush/config.rb
@@ -9,6 +9,7 @@ module Landrush
       @default_upstream = [[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]]
       @default_tld = 'vagrant.dev'
       @upstream_servers = @default_upstream
+      @guest_redirect_dns = true
     end
 
     def enable(enabled=true)
@@ -21,6 +22,14 @@ module Landrush
 
     def enabled?
       @enabled
+    end
+
+    def guest_redirect_dns=(guest_redirect_dns=true)
+      @guest_redirect_dns=guest_redirect_dns
+    end
+
+    def guest_redirect_dns?
+      @guest_redirect_dns
     end
 
     def host(hostname, ip_address=nil)
@@ -45,7 +54,7 @@ module Landrush
         @upstream_servers.push [:tcp, ip, port]
       else
         @upstream_servers.push [protocol, ip, port]
-      end 
+      end
     end
 
     def merge(other)


### PR DESCRIPTION
comes in handy when the host has more complex dns routing that you want
the guests to use (which I am with virtual box's dns nat-ing).
