### PR TITLE
ifconfig not on PATH

### DIFF
--- a/lib/landrush/cap/linux/read_host_visible_ip_address.rb
+++ b/lib/landrush/cap/linux/read_host_visible_ip_address.rb
@@ -22,7 +22,7 @@ module Landrush
         # TODO: Find a better heuristic for this implementation.
         #
         def self.read_host_visible_ip_address(machine)
-          command = "ifconfig  | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'"
+          command = "PATH=$PATH:/sbin ifconfig  | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'"
           result  = ""
           machine.communicate.execute(command) do |type, data|
             result << data if type == :stdout

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,7 +84,7 @@ def fake_machine(options={})
 
   machine.instance_variable_set("@communicator", RecordingCommunicator.new)
   machine.communicate.stub_command(
-    "ifconfig  | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'",
+    "PATH=$PATH:/sbin ifconfig  | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'",
     "#{options.fetch(:ip, '1.2.3.4')}\n"
   )
 


### PR DESCRIPTION
On Debian `ifconfig` resides in `/sbin/ifconfig`. When logged in as non-root (`vagrant` in my case) `/sbin` is not on the PATH.
I'm not sure this is the best solution. Another one would be to use `sudo`, but this might have other unwanted side effects.

@phinze what do you think?
