### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/lib/landrush/version.rb
+++ b/lib/landrush/version.rb
@@ -1,3 +1,3 @@
 module Landrush
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
Changes:
- Remove deprecated "require_plugin" in Vagrantfile (#48, njam)
- A new setting to override the IP address auto-detection. (#37, amfranz)
- Add travis config (#50, njam)
- Fixed comparison of Parallels provider version (#46, legal90)
- Use server's configured port instead of hardcoded 10053 (#49, njam)
- Handle DNS requests in a case-insensitive way (#43, aromanovich)
- Use "ip addr show" to detect ip address (#52, njam)
- option to disable guest dns redirect (#45, grepnull)

@phinze please review and release if you agree
