### PR TITLE
Landrush plugin synopsis for "vagrant help".

### DIFF
--- a/lib/landrush/command.rb
+++ b/lib/landrush/command.rb
@@ -2,6 +2,10 @@ module Landrush
   class Command < Vagrant.plugin('2', :command)
     DAEMON_COMMANDS = %w(start stop restart status)
 
+    def self.synopsis
+      "manages DNS for both guest and host"
+    end
+
     def execute
       ARGV.shift # flush landrush from ARGV, RExec wants to use it for daemon commands
 


### PR DESCRIPTION
This adds a description for the "vagrant landrush" command into the output of "vagrant help".
