### PR TITLE
Set DNS entry TTL to 0

### DIFF
--- a/lib/landrush/server.rb
+++ b/lib/landrush/server.rb
@@ -54,7 +54,7 @@ module Landrush
         match(/.*/, IN::A) do |transaction|
           host = Store.hosts.find(transaction.name)
           if host
-            transaction.respond!(Store.hosts.get(host))
+            transaction.respond!(Store.hosts.get(host), {:ttl => 0})
           else
             transaction.passthrough!(server.upstream)
           end


### PR DESCRIPTION
Since the DNS entries for VMs can potentially change at any moment I suggest they should not be cached (by `mDNSResponder`).
@phinze @kris-lab please review
