### PR TITLE
Make the log output less chatty.

### DIFF
--- a/lib/landrush/action/setup.rb
+++ b/lib/landrush/action/setup.rb
@@ -52,8 +52,10 @@ module Landrush
       def setup_static_dns
         config.hosts.each do |hostname, dns_value|
           dns_value ||= machine.guest.capability(:read_host_visible_ip_address)
-          info "adding static entry: #{hostname} => #{dns_value}"
-          Store.hosts.set hostname, dns_value
+          if !Store.hosts.has?(hostname, dns_value)
+            info "adding static entry: #{hostname} => #{dns_value}"
+            Store.hosts.set hostname, dns_value
+          end
         end
       end
 
@@ -61,14 +63,15 @@ module Landrush
         ip_address = machine.config.landrush.host_ip_address ||
                      machine.guest.capability(:read_host_visible_ip_address)
 
-        info "adding machine entry: #{machine_hostname} => #{ip_address}"
-
         if not machine_hostname.match(config.tld)
           log :error, "hostname #{machine_hostname} does not match the configured TLD: #{config.tld}"
           log :error, "You will not be able to access #{machine_hostname} from the host"
         end
 
-        Store.hosts.set(machine_hostname, ip_address)
+        if !Store.hosts.has?(machine_hostname, ip_address)
+          info "adding machine entry: #{machine_hostname} => #{ip_address}"
+          Store.hosts.set(machine_hostname, ip_address)
+        end
       end
 
       def private_network_exists?

--- a/lib/landrush/action/teardown.rb
+++ b/lib/landrush/action/teardown.rb
@@ -16,21 +16,22 @@ module Landrush
         if DependentVMs.none?
           teardown_static_dns
           teardown_server
-        else
-          info "there are #{DependentVMs.count} VMs left, leaving DNS server and static entries"
-          info DependentVMs.list.map { |dvm| " - #{dvm}" }.join("\n")
         end
       end
 
       def teardown_machine_dns
-        info "removing machine entry: #{machine_hostname}"
-        Store.hosts.delete(machine_hostname)
+        if Store.hosts.has? machine_hostname
+          info "removing machine entry: #{machine_hostname}"
+          Store.hosts.delete(machine_hostname)
+        end
       end
 
       def teardown_static_dns
         config.hosts.each do |static_hostname, _|
-          info "removing static entry: #{static_hostname}"
-          Store.hosts.delete static_hostname
+          if Store.hosts.has? static_hostname
+            info "removing static entry: #{static_hostname}"
+            Store.hosts.delete static_hostname
+          end
         end
       end
 

--- a/lib/landrush/resolver_config.rb
+++ b/lib/landrush/resolver_config.rb
@@ -23,7 +23,7 @@ module Landrush
     end
 
     def info(msg)
-      @env[:ui].info(msg)
+      @env[:ui].info("[landrush] #{msg}")
     end
 
     def desired_contents; <<-EOS.gsub(/^      /, '')
@@ -61,11 +61,6 @@ module Landrush
     end
 
     def ensure_config_exists!
-      unless osx?
-        puts "Not an OSX machine, so skipping host DNS resolver config."
-        return
-      end
-
       if contents_match?
         info "Host DNS resolver config looks good."
       else

--- a/lib/landrush/store.rb
+++ b/lib/landrush/store.rb
@@ -26,6 +26,14 @@ module Landrush
       write(current_config.reject { |k, _| k == key })
     end
 
+    def has?(key, value = nil)
+      if value.nil?
+        current_config.has_key? key
+      else
+        current_config[key] == value
+      end
+    end
+
     def find(search)
       current_config.keys.detect do |key|
         key.casecmp(search) == 0   ||


### PR DESCRIPTION
This includes the following changes:
- Log messages about adding a DNS record are shown only if the record
  does not exist already and log messages about removing a DNS record
  are shown only if the DNS record exists. This avoids unnecessary log
  chatter when working with static DNS records defined on the global
  level in a Vagrantfile that contains multiple VMs. Previously log
  messages about those static DNS records would have been shown every
  time a VM was started, now they are only shown when starting the first
  VM.
- Just like most log messages already have been, now log output from the
  DNS resolver logic is prefixed with "[landrush] " as well.
- A new configuration setting "quiet" that if set to true, will hide the
  following messages which are useful on the first day to get insight
  about what's happening under the covers but are pretty useless once
  you understand how landrush works:
  - "Not an OSX machine, so skipping host DNS resolver config."
  - "there are #{DependentVMs.count} VMs left, leaving DNS server and static entries"
  
  This setting is false by default so that the old behaviour stays the default.
