### PR TITLE
switch to assignment style enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install under Vagrant (1.1 or later):
 
 Enable the plugin in your `Vagrantfile`:
 
-    config.landrush.enable
+    config.landrush.enabled = true
 
 Bring up a machine that has a hostname set (see the `Vagrantfile` for an example)
 

--- a/lib/landrush/config.rb
+++ b/lib/landrush/config.rb
@@ -24,8 +24,8 @@ module Landrush
       @guest_redirect_dns = UNSET_VALUE
     end
 
-    def enable(enabled=true)
-      @enabled = enabled
+    def enable
+      @enabled = true
     end
 
     def disable
@@ -33,7 +33,7 @@ module Landrush
     end
 
     def enabled?
-      @enabled
+      !!@enabled
     end
 
     def guest_redirect_dns?

--- a/test/landrush/action/setup_test.rb
+++ b/test/landrush/action/setup_test.rb
@@ -77,9 +77,8 @@ module Landrush
         it "does nothing if it is not enabled via config" do
           app = Proc.new {}
           setup = Setup.new(app, nil)
-          env = fake_environment
+          env = fake_environment(enabled: false)
 
-          env[:machine].config.landrush.disable
           setup.call(env)
 
           Store.hosts.get('somehost.vagrant.dev').must_equal nil

--- a/test/landrush/config_test.rb
+++ b/test/landrush/config_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe 'Landrush::Config' do
+  it "supports enabling via accessor style" do
+    machine = fake_machine
+    config = machine.config.landrush
+
+    machine.config.landrush.enabled = true
+    config.enabled?.must_equal true
+    machine.config.landrush.enabled = false
+    config.enabled?.must_equal false
+  end
+
+  it "is backwards-compatible with the old method call style" do
+    machine = fake_machine
+    config = machine.config.landrush
+
+    machine.config.landrush.enable
+    config.enabled?.must_equal true
+    machine.config.landrush.disable
+    config.enabled?.must_equal false
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ require 'landrush/cap/linux/read_host_visible_ip_address'
 
 require 'minitest/autorun'
 
-def fake_environment(options={})
+def fake_environment(options = { enabled: true })
   { machine: fake_machine(options), ui: FakeUI }
 end
 
@@ -89,7 +89,7 @@ def fake_machine(options={})
     "#{options.fetch(:ip, '1.2.3.4')}\n"
   )
 
-  machine.config.landrush.enable
+  machine.config.landrush.enabled = options.fetch(:enabled, false)
   machine.config.vm.hostname = options.fetch(:hostname, 'somehost.vagrant.dev')
 
   machine


### PR DESCRIPTION
matches more closely with general vagrant styyle

backwards compatible with old methods
