### PR TITLE
explicitly use bundler 1.5.3 to avoid vagrant dep problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ rvm:
 
 before_install:
   - sudo apt-get install dnsutils
+  - gem uninstall --ignore-dependencies --executables --all bundler
+  - gem install bundler --version '1.5.3'


### PR DESCRIPTION
was seeing the following in travis build:

> Bundler could not find compatible versions for gem "bundler":
>   In Gemfile:
>     vagrant (>= 0) ruby depends on
>       bundler (~> 1.5.2) ruby
>   Current Bundler version:
>     bundler (1.6.1)

see: https://travis-ci.org/phinze/landrush/builds/24335968
