### PR TITLE
add a guard to wait until machine communication is available

### DIFF
--- a/lib/landrush/action/install_prerequisites.rb
+++ b/lib/landrush/action/install_prerequisites.rb
@@ -10,6 +10,7 @@ module Landrush
       end
 
       def install_prerequisites
+        machine.communicate.wait_for_ready(60)
         unless machine.guest.capability(:iptables_installed)
           info 'iptables not installed, installing it'
           machine.guest.capability(:install_iptables)


### PR DESCRIPTION
centos seems to enable ssh later in the boot process, triggering a race condition where landrush
tries to communicate with the machine before ssh is available. We can guard the execution of the
landrush capabilities check and wait until machine communication is available. This fixes #79.
