### PR TITLE
cannot bring VM up after enabling landrush

### DIFF
--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -67,16 +67,11 @@ module Landrush
       end
 
       def read_machine_hostname
-        # Get hostname from vm config.
-        return machine.config.vm.hostname if machine.config.vm.hostname.to_s.length > 0
-
-        # Or gt machine's current hostname.
-        machine.communicate.execute("hostname") do |type, data|
-          return data if type == :stdout && data.to_s.length > 0
+        if machine.config.vm.hostname
+          return machine.config.vm.hostname
         end
 
-        # Or default to "guest-vm"
-        return "guest-vm"
+        "#{Pathname.pwd.basename}.#{config.tld}"
       end
 
       def enabled?


### PR DESCRIPTION
When I enable landrush on my VagrantFile the VM won't start anymore. I'm running Vagrant on osx 10.9.5.

VagrantFile looks like:

```
# -*- mode: ruby -*-
# vi: set ft=ruby :

# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
VAGRANTFILE_API_VERSION = "2"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "ubuntu/trusty64"
  config.landrush.enabled = true
  config.vm.provision "ansible" do |ansible|
    ansible.playbook = "scripts/vagrant/provisioning/playbook.yml"
  end
end
```

And when I run `vagrant up`

```
$  vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/trusty64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
==> default: Setting the name of the VM: open-data_default_1413290046415_45839
==> default: Clearing any previously set forwarded ports...
==> default: Clearing any previously set network interfaces...
The provider for this Vagrant-managed machine is reporting that it
is not yet ready for SSH. Depending on your provider this can carry
different meanings. Make sure your machine is created and running and
try again. Additionally, check the output of `vagrant status` to verify
that the machine is in the state that you expect. If you continue to
get this error message, please view the documentation for the provider
you're using.
```

When I disable the landrush from VagrantFile then everything works. 
