### PR TITLE
Issue #177 Allow multiple TLD and resolver configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ If you would like to configure your guests to be accessible from the host as sub
 
     config.landrush.tld = 'vm'
 
+Multiple TLD can also be provided as an array. On OS X, a resolver configuration will be created for each TLD.
+
+    config.landrush.tld = ['vm', 'dev']
+
 Note that from the __host__, you will only be able to access subdomains of your configured TLD by default- so wildcard subdomains only apply to that space. For the __guest__, wildcard subdomains work for anything.
 
 ### Unmatched Queries

--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -71,7 +71,7 @@ module Landrush
           return machine.config.vm.hostname
         end
 
-        "#{Pathname.pwd.basename}.#{config.tld}"
+        "#{Pathname.pwd.basename}.#{config.tld[0]}"
       end
 
       def enabled?

--- a/lib/landrush/action/setup.rb
+++ b/lib/landrush/action/setup.rb
@@ -28,7 +28,9 @@ module Landrush
       end
 
       def setup_host_resolver
-        ResolverConfig.new(env).ensure_config_exists!
+        config.tld.each { |tld|
+          ResolverConfig.new(env, tld).ensure_config_exists!
+        }
       end
 
       def add_prerequisite_network_interface
@@ -64,8 +66,15 @@ module Landrush
         ip_address = machine.config.landrush.host_ip_address ||
                      machine.guest.capability(:read_host_visible_ip_address)
 
-        if not machine_hostname.match(config.tld)
-          log :error, "hostname #{machine_hostname} does not match the configured TLD: #{config.tld}"
+        tld_match = false
+        config.tld.each { |tld|
+          if machine_hostname.match(tld)
+            tld_match = true
+            break
+          end
+        }
+        if !tld_match
+          log :error, "hostname #{machine_hostname} does not match any of the configured TLD: #{config.tld}"
           log :error, "You will not be able to access #{machine_hostname} from the host"
         end
 

--- a/lib/landrush/config.rb
+++ b/lib/landrush/config.rb
@@ -36,6 +36,10 @@ module Landrush
       !!@enabled
     end
 
+    def tld
+      Array(@tld)
+    end
+
     def guest_redirect_dns?
       @guest_redirect_dns
     end

--- a/lib/landrush/resolver_config.rb
+++ b/lib/landrush/resolver_config.rb
@@ -18,8 +18,9 @@ module Landrush
       self.class.config_dir
     end
 
-    def initialize(env={})
+    def initialize(env={}, tld)
       @env = env
+      @tld = tld
     end
 
     def info(msg)
@@ -42,7 +43,7 @@ module Landrush
     end
 
     def config_file
-      config_dir.join(@env[:machine].config.landrush.tld)
+      config_dir.join(@tld)
     end
 
     def contents_match?
@@ -50,7 +51,7 @@ module Landrush
     end
 
     def write_config!
-      info "Momentarily using sudo to put the host config in place..."
+      info "Momentarily using sudo to put a TLD config in place..."
       system "#{self.class.sudo} mkdir #{config_dir}" unless config_dir.directory?
       Tempfile.open('vagrant_landrush_host_config') do |f|
         f.write(desired_contents)


### PR DESCRIPTION
This PR allows `landrush.tld` to take an array of TLD values. Landrush will create OS X resolver configurations for each TLD. There is no change to the existing syntax for assigning a single value.

An example Vagrant configuration would look like

```
config.landrush.tld = ['vm.example.com', 'vm.test.org']
config.landrush.host 'www.vm.example.com', HOST_IP
config.landrush.host 'www.vm.test.org', HOST_IP
```

An example benefit for multiple TLD comes when running multiple websites on a single virtual machine using Apache/Nginx name-based vhosting. That is, a VM can host www.vm.example.com and www.vm.test.org and clients can resolve both domains.
