### PR TITLE
Acceptance tests: cucumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,7 @@ group :development do
   gem 'byebug'
   gem 'mocha'
   gem 'minitest'
+  gem 'cucumber', '~> 2.1'
+  gem 'aruba', '~> 0.13'
+  gem 'komenda', '~> 0.0.4'
 end

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Run the test suite:
 
     bundle exec rake
 
+Run cucumber/aruba acceptance tests:
+
+    bundle exec cucumber
+
 Run the vagrant binary with the landrush plugin loaded from your local source code:
 
     bundle exec vagrant landrush <command>

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'
+require 'cucumber/rake/task'
 
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
@@ -17,3 +18,5 @@ task :generate_diagrams do
 end
 
 RuboCop::RakeTask.new
+
+Cucumber::Rake::Task.new(:features)

--- a/features/dns_resolution.feature
+++ b/features/dns_resolution.feature
@@ -1,0 +1,24 @@
+Feature: dns_resolution
+  Landrush should make a virtual machine's IP address DNS-resolvable.
+
+  Scenario Outline: booting a box
+    Given a file named "Vagrantfile" with:
+    """
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.hostname = 'my-host.my-tld'
+      config.vm.network :private_network, ip: '10.10.10.123'
+
+      config.landrush.enabled = true
+      config.landrush.tld = 'my-tld'
+    end
+    """
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    Then the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the internal DNS server
+    And the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the host
+    And the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the guest
+
+    Examples:
+      | box             | provider   |
+      | debian/jessie64 | virtualbox |
+      | ubuntu/wily64   | virtualbox |

--- a/features/step_definitions/dns.rb
+++ b/features/step_definitions/dns.rb
@@ -1,0 +1,20 @@
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the internal DNS server$/) do |host, ip|
+  run("dig +short @localhost -p 10053 '#{host}' A")
+  expect(last_command_started).to have_output(/^#{ip}$/)
+end
+
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the host$/) do |host, ip|
+  if RbConfig::CONFIG['host_os'] =~ /darwin|mac os/
+    run('sudo killall -HUP mDNSResponder')
+    run("ping -c 1 -t 1 '#{host}'")
+    expect(last_command_started).to have_output(/\(#{ip}\)/)
+  else
+    run("dig +short '#{host}' A")
+    expect(last_command_started).to have_output(/^#{ip}$/)
+  end
+end
+
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the guest/) do |host, ip|
+  run("vagrant ssh -c \"dig +short '#{host}' A\"")
+  expect(last_command_started).to have_output(/^#{ip}$/)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,14 @@
+require 'aruba/cucumber'
+require 'komenda'
+
+Aruba.configure do |config|
+  config.exit_timeout = 300
+  config.activate_announcer_on_command_failure = [:stdout, :stderr]
+end
+
+After do |_scenario|
+  if File.exist?(File.join(aruba.config.working_directory, 'Vagrantfile'))
+    result = Komenda.run('vagrant destroy -f', cwd: aruba.config.working_directory)
+    fail "Unable to destroy vagrant environment:\n#{result.output}" unless result.success?
+  end
+end


### PR DESCRIPTION
Run with:
```
bundle exec rake features
```

Todo:
Upgrade to Aruba 0.13, and add:
```rb
    Aruba.configure do |config|
      config.activate_announcer_on_command_failure = [:stdout, :stderr]
    end
```