### PR TITLE
Acceptance tests: cucumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,7 @@ group :development do
   gem 'byebug'
   gem 'mocha'
   gem 'minitest'
+  gem 'cucumber', '~> 2.1'
+  gem 'aruba', '~> 0.13'
+  gem 'komenda', '~> 0.1.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,17 +30,39 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    aruba (0.14.1)
+      childprocess (~> 0.5.6)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9.10)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
     ast (2.2.0)
     builder (3.2.2)
     byebug (8.2.1)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    contracts (0.13.0)
+    cucumber (2.3.3)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.4.0)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 3.2.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.4.0)
+      gherkin (~> 3.2.0)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.2.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.8)
+    events (0.9.8)
     ffi (1.9.10)
     ffi (1.9.10-x64-mingw32)
+    gherkin (3.2.0)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
@@ -51,6 +73,8 @@ GEM
     httpclient (2.7.1)
     i18n (0.7.0)
     json (1.8.3)
+    komenda (0.1.6)
+      events (~> 0.9.8)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -66,6 +90,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
+    multi_test (0.1.2)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -96,6 +121,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     rubocop (0.38.0)
       parser (>= 2.3.0.6, < 3.0)
       powerpack (~> 0.1)
@@ -107,6 +136,7 @@ GEM
       eventmachine (~> 1.0.0)
     rubyntlm (0.4.0)
     rubyzip (1.1.7)
+    thor (0.19.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -134,8 +164,11 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  aruba (~> 0.13)
   byebug
+  cucumber (~> 2.1)
   json
+  komenda (~> 0.1.6)
   landrush!
   minitest
   mocha
@@ -143,3 +176,6 @@ DEPENDENCIES
   rubocop (~> 0.38.0)
   rubydns (= 0.8.5)
   vagrant!
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ Clean generated files:
 
     bundle exec rake clobber
 
+Run cucumber/aruba acceptance tests:
+
+    bundle exec cucumber
+
 Run the vagrant binary with the Landrush plugin loaded from your local
 source code:
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rake'
 require 'rake/testtask'
 require 'rake/clean'
 require 'rubocop/rake_task'
+require 'cucumber/rake/task'
 
 CLOBBER.include('pkg/*')
 
@@ -35,3 +36,5 @@ task :generate_diagrams do
 end
 
 RuboCop::RakeTask.new
+
+Cucumber::Rake::Task.new(:features)

--- a/features/dns_resolution.feature
+++ b/features/dns_resolution.feature
@@ -1,0 +1,24 @@
+Feature: dns_resolution
+  Landrush should make a virtual machine's IP address DNS-resolvable.
+
+  Scenario Outline: booting a box
+    Given a file named "Vagrantfile" with:
+    """
+    Vagrant.configure('2') do |config|
+      config.vm.box = '<box>'
+      config.vm.hostname = 'my-host.my-tld'
+      config.vm.network :private_network, ip: '10.10.10.123'
+
+      config.landrush.enabled = true
+      config.landrush.tld = 'my-tld'
+    end
+    """
+    When I successfully run `bundle exec vagrant up --provider <provider>`
+    Then the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the internal DNS server
+    And the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the host
+    And the hostname "my-host.my-tld" should resolve to "10.10.10.123" on the guest
+
+    Examples:
+      | box             | provider   |
+      | debian/jessie64 | virtualbox |
+      | ubuntu/wily64   | virtualbox |

--- a/features/step_definitions/dns.rb
+++ b/features/step_definitions/dns.rb
@@ -1,0 +1,19 @@
+require 'landrush/server'
+
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the internal DNS server$/) do |host, ip|
+  port = Landrush::Server.port
+  resolver = Resolv::DNS.new(:nameserver_port => [['localhost', port]], :search => ['local'], :ndots => 1)
+  ip_resolved = resolver.getaddress(host).to_s
+  expect(ip_resolved).to eq(ip)
+end
+
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the host$/) do |host, ip|
+  addrinfo = Addrinfo.getaddrinfo(host, nil, Socket::AF_INET)
+  ip_resolved = addrinfo.first.ip_address
+  expect(ip_resolved).to eq(ip)
+end
+
+Then(/^the hostname "([^"]+)" should resolve to "([^"]+)" on the guest/) do |host, ip|
+  run("vagrant ssh -c \"dig +short '#{host}' A\"")
+  expect(last_command_started).to have_output(/^#{ip}$/)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,15 @@
+require 'aruba/cucumber'
+require 'komenda'
+
+Aruba.configure do |config|
+  config.exit_timeout = 300
+  config.activate_announcer_on_command_failure = [:stdout, :stderr]
+end
+
+After do |_scenario|
+  Komenda.run('bundle exec vagrant landrush stop', fail_on_fail: true)
+
+  if File.exist?(File.join(aruba.config.working_directory, 'Vagrantfile'))
+    Komenda.run('bundle exec vagrant destroy -f', cwd: aruba.config.working_directory, fail_on_fail: true)
+  end
+end


### PR DESCRIPTION
Continuation of #144, part of #136

Run with:
```
bundle exec rake features
```