### PR TITLE
Issue #165 Support for CentOS v5 boxes 

### DIFF
--- a/lib/landrush/cap/linux/add_iptables_rule.rb
+++ b/lib/landrush/cap/linux/add_iptables_rule.rb
@@ -3,7 +3,7 @@ module Landrush
     module Linux
       module AddIptablesRule
         def self.add_iptables_rule(machine, rule)
-          _run(machine, %Q(iptables -C #{rule} 2> /dev/null || iptables -A #{rule}))
+          _run(machine, %Q(/sbin/iptables -C #{rule} || /sbin/iptables -A #{rule}))
         end
 
         def self._run(machine, command)

--- a/lib/landrush/cap/linux/configured_dns_servers.rb
+++ b/lib/landrush/cap/linux/configured_dns_servers.rb
@@ -4,9 +4,9 @@ module Landrush
       module ConfiguredDnsServers
         def self.configured_dns_servers(machine)
           return @dns_servers if @dns_servers
-          machine.communicate.sudo('cat /etc/resolv.conf | grep ^nameserver') do |type, data|
+          machine.communicate.sudo('sed -ne \'s/^nameserver \([0-9.]*\)$/\1/p\' /etc/resolv.conf') do |type, data|
             if type == :stdout
-              @dns_servers = Array(data.scan(/\d+\.\d+\.\d+\.\d+/))
+              @dns_servers = Array(data.scan(/\d+\.\d+\.\d+\.\d+/)) unless data.to_s.empty?
             end
           end
           @dns_servers

--- a/lib/landrush/cap/linux/read_host_visible_ip_address.rb
+++ b/lib/landrush/cap/linux/read_host_visible_ip_address.rb
@@ -39,7 +39,7 @@ module Landrush
         end
 
         def self.command
-          %Q(hostname -I)
+          %Q(hostname -I 2>/dev/null || /sbin/ip ad | sed -ne 's/^\\W*inet \\([0-9.]*\\).* global .*$/\\1/p' 2>/dev/null)
         end
       end
     end


### PR DESCRIPTION
Minor changes to enable Linux CentOS v5 to work correctly with Landrush.

Tested OK on CentOS versions 5, 6, 7
