### PR TITLE
Issue #236 and #237 Explicitly calling landrush_ip_install and making sure the right path is built on Windows

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,6 +21,7 @@ Metrics/AbcSize:
   Max: 36
   Exclude:
     - 'lib/landrush/command.rb'
+    - 'lib/landrush/cap/guest/all/read_host_visible_ip_address.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
+++ b/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
@@ -17,6 +17,8 @@ module Landrush
         def self.read_host_visible_ip_address(machine)
           @machine = machine
 
+          @machine.guest.capability(:landrush_ip_install) unless @machine.guest.capability(:landrush_ip_installed)
+
           addr      = nil
           addresses = machine.guest.capability(:landrush_ip_get)
 

--- a/lib/landrush/server.rb
+++ b/lib/landrush/server.rb
@@ -274,7 +274,13 @@ module Landrush
       vagrant_binary = Vagrant::Util::Which.which('vagrant')
       vagrant_binary = File.realpath(vagrant_binary) if File.symlink?(vagrant_binary)
       # in a Vagrant installation the Ruby executable is in ../embedded/bin relative to the vagrant executable
-      embedded_bin_dir = File.join(File.dirname(File.dirname(vagrant_binary)), 'embedded', 'bin')
+      # we don't use File.join here, since even on Cygwin we want a Windows path - see https://github.com/vagrant-landrush/landrush/issues/237
+      if Vagrant::Util::Platform.windows?
+        separator = '\\'
+      else
+        separator = '/'
+      end
+      embedded_bin_dir = File.dirname(File.dirname(vagrant_binary)) + separator + 'embedded' + separator + 'bin'
       ENV['PATH'] = embedded_bin_dir + File::PATH_SEPARATOR + ENV['PATH'] if File.exist?(embedded_bin_dir)
     end
 

--- a/test/landrush/cap/guest/all/read_host_visible_ip_address_test.rb
+++ b/test/landrush/cap/guest/all/read_host_visible_ip_address_test.rb
@@ -14,6 +14,7 @@ module Landrush
         before do
           # TODO: Is there a way to only unstub it for read_host_visible_ip_address?
           machine.guest.unstub(:capability)
+          machine.guest.stubs(:capability).with(:landrush_ip_installed).returns(true)
           machine.guest.stubs(:capability).with(:landrush_ip_get).returns(fake_addresses)
         end
 


### PR DESCRIPTION
Addresses Issue #236 and #237