### PR TITLE
Vagrant would print error message "The system cannot find the path sp…

### DIFF
--- a/lib/landrush/cap/host/debian/host.rb
+++ b/lib/landrush/cap/host/debian/host.rb
@@ -3,6 +3,7 @@ module Landrush
     module Debian
       class DebianHost < Vagrant.plugin('2', 'host')
         def detect?(_env)
+          return false unless Pathname('/etc/issue').exist?
           system("cat /etc/issue | grep 'Debian' > /dev/null 2>&1")
         end
       end


### PR DESCRIPTION
…ecified."  Need to detect the path.