### PR TITLE
Read IP from guest even if there's just 1 private network

### DIFF
--- a/test/landrush/action/setup_test.rb
+++ b/test/landrush/action/setup_test.rb
@@ -57,14 +57,6 @@ module Landrush
         DependentVMs.list.must_equal []
       end
 
-      it "for single private network IP host visible IP can be retrieved w/o starting the VM" do
-        setup = Setup.new(app, nil)
-        env[:machine].config.vm.network :private_network, ip: '42.42.42.42'
-
-        setup.call(env)
-        Store.hosts.get('somehost.vagrant.test').must_equal '42.42.42.42'
-      end
-
       it "for multiple private network IPs host visible IP cant be retrieved if host_ip_address is set" do
         setup = Setup.new(app, nil)
 


### PR DESCRIPTION
Fixes https://github.com/vagrant-landrush/landrush/issues/268

In case we want to use the public network's address.

For example my box has a private and a public address:
```
    config.vm.network :private_network, ip: '10.10.11.10'
    config.vm.network :public_network, :bridge => 'en0: Wi-Fi (AirPort)'
```

And I want to use the public one with:
```
config.landrush.host_interface = 'eth2'
```

For this we will need to use `read_host_visible_ip_address`.

@hferentschik wdyt?