### PR TITLE
Change virtualbox DNS address to 10.0.2.3

### DIFF
--- a/lib/landrush/action/redirect_dns.rb
+++ b/lib/landrush/action/redirect_dns.rb
@@ -24,7 +24,7 @@ module Landrush
       def _target_host
         case provider
         when :virtualbox then
-          '10.0.2.2'
+          '10.0.2.3'
         when :vmware_fusion, :libvirt then
           _gateway_for_ip(machine.guest.capability(:configured_dns_servers).first)
         when :parallels then


### PR DESCRIPTION
> In that case the guest is assigned to the address 10.0.2.15, the gateway is set to 10.0.2.2 and the name server can be found at 10.0.2.3.
https://www.virtualbox.org/manual/ch09.html

Both work for me, but I think 10.0.2.3 is correct.