### PR TITLE
Adds an option to specify interface class for ip selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,16 @@ when no explicit value for `config.landrush.host_interface_excludes` is specifie
 If Landrush fails to detect the correct IP address (or none at all), you can extend this exclusion
 range to exclude more interfaces.
 
+You can also make sure to only select a specific class of IP address (`:ipv4`, `:ipv6` or `:any`). Either way, empty values will not be returned, but in the case of `:any` you may get the IPv6 address for an interface that has no IPv4 address. The default is to return the first non-empty IPv4 address:
+
+    config.landrush.host_interface_class = :ipv4
+
 If you need or want to select an interface explicitly and you know its name, you can also tell
 Landrush to grab that interface's IP address explicitly:
 
     config.landrush.host_interface = 'eth0'
 
-Do note that, if you specify an interface explicitly, it will have priority over
+Do note that if you specify an interface explicitly, it will have priority over
 `config.landrush.host_interface_excludes`. In other words, if `config.landrush.host_interface_excludes`
 is set to `[/eth[0-9]*/]`, but `config.landrush.host_interface` is set to `eth0` and `eth0` exists
 as an interface, the IP address of `eth0` is returned. The interface setting takes precedence over

--- a/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
+++ b/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
@@ -40,7 +40,7 @@ module Landrush
           addr      = nil
           addresses = machine.guest.capability(:landrush_ip_get)
 
-          # Short circuit this one first: if an explicit interface is defined, look for it && return it if found.
+          # Short circuit this one first: if an explicit interface is defined, look for it and return it if found.
           # Technically, we could do a single loop, but execution time is not vital here.
           # This allows us to be more accurate, especially with logging what's going on.
           unless machine.config.landrush.host_interface.nil?

--- a/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
+++ b/lib/landrush/cap/guest/all/read_host_visible_ip_address.rb
@@ -14,15 +14,33 @@ module Landrush
           addresses
         end
 
+        def self.filter_preferred_addresses(addresses)
+          if @machine.config.landrush.host_interface_class == :any
+            addresses = addresses.select do |addr|
+              (addr.key?('ipv4') && !addr['ipv4'].empty?) ||
+                (addr.key?('ipv6') && !addr['ipv6'].empty?)
+            end
+          else
+            key = @machine.config.landrush.host_interface_class.to_s
+
+            addresses = addresses.select do |addr|
+              (addr.key?(key) && !addr[key].empty?)
+            end
+          end
+
+          addresses
+        end
+
         def self.read_host_visible_ip_address(machine)
           @machine = machine
 
-          @machine.guest.capability(:landrush_ip_install) unless @machine.guest.capability(:landrush_ip_installed)
+          # TODO: Remove? No longer necessary with landrush-ip 0.2.4+
+          machine.guest.capability(:landrush_ip_install) unless machine.guest.capability(:landrush_ip_installed)
 
           addr      = nil
           addresses = machine.guest.capability(:landrush_ip_get)
 
-          # Short circuit this one first: if an explicit interface is defined, look for it and return it if found.
+          # Short circuit this one first: if an explicit interface is defined, look for it && return it if found.
           # Technically, we could do a single loop, but execution time is not vital here.
           # This allows us to be more accurate, especially with logging what's going on.
           unless machine.config.landrush.host_interface.nil?
@@ -33,15 +51,24 @@ module Landrush
 
           if addr.nil?
             addresses = filter_addresses addresses
+            raise 'No addresses found' if addresses.empty?
 
+            addresses = filter_preferred_addresses addresses
             raise 'No addresses found' if addresses.empty?
 
             addr = addresses.last
           end
 
-          ip = IPAddr.new(addr['ipv4'])
+          # Keep preferring IPv4 over IPv6.
+          key = if machine.config.landrush.host_interface_class == :any
+                  addr['ipv4'].empty? ? 'ipv6' : 'ipv4'
+                else
+                  machine.config.landrush.host_interface_class.to_s
+                end
 
-          machine.env.ui.info "[landrush] Using #{addr['name']} (#{addr['ipv4']})"
+          ip = IPAddr.new(addr[key])
+
+          machine.env.ui.info "[landrush] Using #{addr['name']} (#{addr[key]})"
 
           ip.to_s
         end

--- a/test/landrush/cap/guest/all/read_host_visible_ip_address_test.rb
+++ b/test/landrush/cap/guest/all/read_host_visible_ip_address_test.rb
@@ -35,7 +35,6 @@ module Landrush
 
             expected = addresses.last['ipv4']
 
-            # call_cap(machine).must_equal expected
             call_cap(machine).must_equal expected
           end
 
@@ -78,6 +77,41 @@ module Landrush
             machine.config.landrush.host_interface_excludes = []
 
             expected = addresses.last['ipv4']
+
+            call_cap(machine).must_equal expected
+          end
+
+          # Now, let's explicitly test the IPv4/IPv6 selection support, starting with the default (IPv4)
+          it 'should return the last non-empty IPv4 address' do
+            machine.config.landrush.host_interface          = nil
+            machine.config.landrush.host_interface_excludes = [/exclude[0-9]+/, /include[0-9]+/]
+
+            expected = addresses.detect { |a| a['name'] == 'ipv6empty2' }
+            expected = expected['ipv4']
+
+            call_cap(machine).must_equal expected
+          end
+
+          # Test IPv6 selection
+          it 'should return the last non-empty IPv6 address' do
+            machine.config.landrush.host_interface          = nil
+            machine.config.landrush.host_interface_class    = :ipv6
+            machine.config.landrush.host_interface_excludes = [/exclude[0-9]+/, /include[0-9]+/]
+
+            expected = addresses.detect { |a| a['name'] == 'ipv4empty2' }
+            expected = expected['ipv6']
+
+            call_cap(machine).must_equal expected
+          end
+
+          # Test ANY selection
+          it 'should return the last non-empty address of either class' do
+            machine.config.landrush.host_interface          = nil
+            machine.config.landrush.host_interface_class    = :any
+            machine.config.landrush.host_interface_excludes = [/exclude[0-9]+/, /include[0-9]+/]
+
+            expected = addresses.detect { |a| a['name'] == 'ipv4empty2' }
+            expected = expected['ipv6']
 
             call_cap(machine).must_equal expected
           end

--- a/test/landrush/config_test.rb
+++ b/test/landrush/config_test.rb
@@ -20,4 +20,25 @@ describe 'Landrush::Config' do
     machine.config.landrush.disable
     config.enabled?.must_equal false
   end
+
+  it "should validate host_interface_class" do
+    machine = fake_machine
+    config = machine.config.landrush
+
+    validation_success = []
+    validation_error = [Landrush::Config::INTERFACE_CLASS_INVALID, { :fields => 'host_interface_class' }]
+
+    Landrush::Config::INTERFACE_CLASSES.each do |sym|
+      machine.config.landrush.host_interface_class = sym
+      config.validate(machine).must_equal('landrush' => validation_success)
+
+      machine.config.landrush.host_interface_class = sym.to_s
+      config.validate(machine).must_equal('landrush' => validation_success)
+    end
+
+    [:invalid_symbol, 'invalid_string', 4].each do |v|
+      machine.config.landrush.host_interface_class = v
+      config.validate(machine).must_equal('landrush' => validation_error)
+    end
+  end
 end

--- a/test/landrush/issues/255.rb
+++ b/test/landrush/issues/255.rb
@@ -1,0 +1,115 @@
+require_relative '../../test_helper'
+
+module Landrush
+  module Cap
+    module All
+      describe ReadHostVisibleIpAddress do
+        let(:landrush_ip_output) do
+          <<YAML
+- name: br-44ba74744d5d
+  ipv4: 172.17.0.1
+  ipv6: fe80::42:e1ff:fe01:ae98
+- name: br-7884014b4104
+  ipv4: 172.19.0.1
+  ipv6: fe80::42:c0ff:fe4b:900c
+- name: br-efce9da0c1fd
+  ipv4: 172.18.0.1
+  ipv6: fe80::42:2ff:fe46:f1d1
+- name: docker0
+  ipv4: 172.16.0.1
+  ipv6: fe80::42:dbff:fe1b:6e92
+- name: docker_gwbridge
+  ipv4: 172.20.0.1
+  ipv6: fe80::42:72ff:fe96:c6df
+- name: enp4s0
+  ipv4: 192.168.88.97
+  ipv6: fe80::323d:9fa0:ef2a:ddf5
+- name: wlp3s0
+  ipv4: 192.168.88.118
+  ipv6: fe80::6b80:15d4:e83c:a59d
+- name: lo
+  ipv4: 127.0.0.1
+  ipv6: ::1/128
+- name: veth050aa01
+  ipv4: ""
+  ipv6: fe80::c83a:8eff:fe7a:3244
+- name: veth1c191f7
+  ipv4: ""
+  ipv6: fe80::b498:f3ff:fea1:3243
+- name: veth38aa771
+  ipv4: ""
+  ipv6: fe80::8c97:e2ff:fe1a:b14f
+- name: veth5f49498
+  ipv4: ""
+  ipv6: fe80::6825:20ff:fef5:a00d
+- name: veth7803c65
+  ipv4: ""
+  ipv6: fe80::34d7:6cff:fe28:54ce
+- name: veth8a09803
+  ipv4: ""
+  ipv6: fe80::b436:30ff:fed1:598e
+- name: veth8bf1652
+  ipv4: ""
+  ipv6: fe80::60a8:67ff:fe85:cce4
+- name: veth95ef8de
+  ipv4: ""
+  ipv6: fe80::9c45:e8ff:fe69:e62f
+- name: vethc75f284
+  ipv4: ""
+  ipv6: fe80::78b2:7fff:fe55:59
+- name: vethe533ef0
+  ipv4: ""
+  ipv6: fe80::b83e:93ff:fe52:aac7
+YAML
+        end
+
+        let(:machine) { fake_machine }
+        let(:addresses) { YAML.load(landrush_ip_output) }
+
+        def call_cap(machine)
+          Landrush::Cap::All::ReadHostVisibleIpAddress.read_host_visible_ip_address(machine)
+        end
+
+        before do
+          # TODO: Is there a way to only unstub it for read_host_visible_ip_address?
+          machine.guest.unstub(:capability)
+          machine.guest.stubs(:capability).with(:landrush_ip_installed).returns(true)
+          machine.guest.stubs(:capability).with(:landrush_ip_get).returns(addresses)
+
+          machine.config.landrush.host_interface          = nil
+          machine.config.landrush.host_interface_excludes = [/lo[0-9]*/, /docker[0-9]+/, /tun[0-9]+/, /br-(.+)/]
+        end
+
+        describe 'Issue 255: read_host_visible_ip_address failure in presence of interface without IPv4, with IPv6 address' do
+          # Test IPv4
+          it 'should return the last non-empty IPv4 address' do
+            expected = addresses.detect { |a| a['name'] == 'wlp3s0' }
+            expected = expected['ipv4']
+
+            call_cap(machine).must_equal expected
+          end
+
+          # Test IPv6 selection
+          it 'should return the last non-empty IPv6 address' do
+            machine.config.landrush.host_interface_class = :ipv6
+
+            expected = addresses.detect { |a| a['name'] == 'vethe533ef0' }
+            expected = expected['ipv6']
+
+            call_cap(machine).must_equal expected
+          end
+
+          # Test ANY selection
+          it 'should return the last non-empty address of either class' do
+            machine.config.landrush.host_interface_class = :any
+
+            expected = addresses.detect { |a| a['name'] == 'vethe533ef0' }
+            expected = expected['ipv6']
+
+            call_cap(machine).must_equal expected
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,10 @@ require 'mocha/mini_test'
 # Putting include/exclude out of order is kind of the point though ;)
 def fake_addresses
   [
+    {'name' => 'ipv6empty1', 'ipv4' => '172.28.128.10', 'ipv6' => ''},
+    {'name' => 'ipv4empty1', 'ipv4' => '', 'ipv6' => '::10'},
+    {'name' => 'ipv6empty2', 'ipv4' => '172.28.128.11', 'ipv6' => ''},
+    {'name' => 'ipv4empty2', 'ipv4' => '', 'ipv6' => '::11'},
     {'name' => 'exclude1', 'ipv4' => '172.28.128.1', 'ipv6' => '::1'},
     {'name' => 'include1', 'ipv4' => '172.28.128.2', 'ipv6' => '::2'},
     {'name' => 'include2', 'ipv4' => '172.28.128.3', 'ipv6' => '::3'},


### PR DESCRIPTION
By default we look for IPv4 addresses (as that's still the most common use case and is unlikely to change in the near future). If one so desires, we can look explicitly for IPv6 or just any address now though.