### PR TITLE
Issue #282 Adding Suse capabilities

### DIFF
--- a/lib/landrush/cap/guest/suse/add_iptables_rule.rb
+++ b/lib/landrush/cap/guest/suse/add_iptables_rule.rb
@@ -1,0 +1,20 @@
+module Landrush
+  module Cap
+    module Suse
+      module AddIptablesRule
+        def self.add_iptables_rule(machine, rule)
+          _run(machine, %(/usr/sbin/iptables -C #{rule} 2> /dev/null || /usr/sbin/iptables -A #{rule}))
+        end
+
+        def self._run(machine, command)
+          machine.communicate.sudo(command) do |data, type|
+            if [:stderr, :stdout].include?(type)
+              color = (type == :stdout) ? :green : :red
+              machine.env.ui.info(data.chomp, color: color, prefix: false)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/cap/guest/suse/install_iptables.rb
+++ b/lib/landrush/cap/guest/suse/install_iptables.rb
@@ -1,0 +1,14 @@
+module Landrush
+  module Cap
+    module Suse
+      module InstallIptables
+        def self.install_iptables(machine)
+          machine.communicate.tap do |c|
+            c.sudo('zypper -q clean')
+            c.sudo('zypper -n -q install iptables')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/cap/guest/suse/iptables_installed.rb
+++ b/lib/landrush/cap/guest/suse/iptables_installed.rb
@@ -1,0 +1,11 @@
+module Landrush
+  module Cap
+    module Suse
+      module IptablesInstalled
+        def self.iptables_installed(machine)
+          machine.communicate.test('rpm -qa | grep iptables')
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/cap/host/suse/dnsmasq_installed.rb
+++ b/lib/landrush/cap/host/suse/dnsmasq_installed.rb
@@ -1,0 +1,11 @@
+module Landrush
+  module Cap
+    module Suse
+      module DnsmasqInstalled
+        def self.dnsmasq_installed(_env, *_args)
+          system('rpm -qa | grep dnsmasq > /dev/null 2>&1')
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/cap/host/suse/install_dnsmasq.rb
+++ b/lib/landrush/cap/host/suse/install_dnsmasq.rb
@@ -1,0 +1,14 @@
+module Landrush
+  module Cap
+    module Suse
+      module InstallDnsmasq
+        class << self
+          def install_dnsmasq(_env)
+            system('sudo zypper -q clean > /dev/null 2>&1')
+            system('sudo zypper -n -q install dnsmasq > /dev/null 2>&1')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/cap/host/suse/restart_dnsmasq.rb
+++ b/lib/landrush/cap/host/suse/restart_dnsmasq.rb
@@ -1,0 +1,23 @@
+module Landrush
+  module Cap
+    module Suse
+      module RestartDnsmasq
+        class << self
+          SED_COMMAND = <<-EOF.gsub(/^ +/, '')
+          sudo sed -i.orig '1 i\
+          # Added by landrush, a vagrant plugin \\
+          nameserver 127.0.0.1 \\
+          ' /etc/resolv.conf
+          EOF
+
+          def restart_dnsmasq(_env)
+            # TODO: At some stage we might want to make create_dnsmasq_config host specific and add the resolv.conf
+            # changes there which seems more natural
+            system(SED_COMMAND) unless system("cat /etc/resolv.conf | grep 'nameserver 127.0.0.1' > /dev/null 2>&1")
+            system('sudo systemctl restart dnsmasq')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/landrush/plugin.rb
+++ b/lib/landrush/plugin.rb
@@ -87,6 +87,21 @@ module Landrush
       Cap::Redhat::InstallIptables
     end
 
+    guest_capability('suse', 'add_iptables_rule') do
+      require_relative 'cap/guest/suse/add_iptables_rule'
+      Cap::Suse::AddIptablesRule
+    end
+
+    guest_capability('suse', 'iptables_installed') do
+      require_relative 'cap/guest/suse/iptables_installed'
+      Cap::Suse::IptablesInstalled
+    end
+
+    guest_capability('suse', 'install_iptables') do
+      require_relative 'cap/guest/suse/install_iptables'
+      Cap::Suse::InstallIptables
+    end
+
     guest_capability('linux', 'configured_dns_servers') do
       require_relative 'cap/guest/linux/configured_dns_servers'
       Cap::Linux::ConfiguredDnsServers
@@ -165,6 +180,21 @@ module Landrush
     host_capability('redhat', 'restart_dnsmasq') do
       require_relative 'cap/host/redhat/restart_dnsmasq'
       Cap::Redhat::RestartDnsmasq
+    end
+
+    host_capability('suse', 'dnsmasq_installed') do
+      require_relative 'cap/host/suse/dnsmasq_installed'
+      Cap::Suse::DnsmasqInstalled
+    end
+
+    host_capability('suse', 'install_dnsmasq') do
+      require_relative 'cap/host/suse/install_dnsmasq'
+      Cap::Suse::InstallDnsmasq
+    end
+
+    host_capability('suse', 'restart_dnsmasq') do
+      require_relative 'cap/host/suse/restart_dnsmasq'
+      Cap::Suse::RestartDnsmasq
     end
   end
 end


### PR DESCRIPTION
Issue #282

Tested on guests:

- opensuse/openSUSE-42.1-x86_64
- opensuse/openSUSE-13.2-x86_64
- opensuse/openSUSE-13.1-x86_64
- suse/sles11sp3

Note that on 13.1 one seems to need to provide the full path to /usr/sbin/iptables

Host not tested.