### PR TITLE
Fix #264, Converted markdown doc to asciidoc, and split the doc into …

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,91 @@
+= Contributing to Landrush
+:toc:
+:toc-placement!:
+
+The following is a set of guidelines for contributing to Landrush. These
+are just guidelines. Please use your best judgment and feel free to
+propose changes to this document in a pull request.
+
+'''
+toc::[]
+'''
+
+At this point, this document is not complete, but as decisions are made
+they will be added to this document.
+
+== Working on an issue
+
+* All changes should have a matching issue in the GitHub
+https://github.com/vagrant-landrush/landrush/issues[issue tracker]. If
+there is not one, create one.
+* Prepend each commit of a proposed change with the GitHub issue number,
+eg `Issue #xyz Fixing foo in bar`
+* All changes should be applied to master via
+https://help.github.com/articles/using-pull-requests/[pull requests]
+(even from maintainers).
+* All changes should include documentation updates.
+* Small changes need only one ACK while larger changes need two ACKs from
+maintainers before they will be merged. If the author of the pull
+request is a maintainer, the submission is considered one of the two ACKs.
+Therefore pull requests from maintainers only require one additional
+ACK.
+
+By "two ACKs" we mean that two maintainers must acknowledge that the change
+is a good one. The second person to ACK the pull request should merge the
+pull request with a comment including their agreement. We default to
+moving forward and using revert if needed.
+
+== Merging pull requests
+
+The merging committer should merge the pull request as follows.
+Avoid using the GitHub web UI. Instead, perform merges using the `git`
+command line. This avoids merge commits and keeps a linear commit
+history. The commands below demonstrate the suggested process.
+
+----
+# Create a local branch for the pull request $ git checkout -b
+master
++
+# Pull the changes $ git pull
++
+# If necessary rebase changes on master to ensure we have a fast #
+forward. Also resolve any conflicts $ git rebase -i master
++
+# Merge changes into master $ git checkout master $ git merge
++
+# Update changelog in the unreleased section. Commit!
++
+# Push to origin $ git push origin master ```
+----
+
+== Releasing
+
+Prerequisites:
+
+* Push access to the `landrush` GitHub repository
+* Owner of the `landrush` gem Rubygems
+
+Steps:
+
+. Update `lib/landrush/version.rb` with the new version number.
+. Update the `CHANGELOG.md` header with the new version number and
+current date.
+. Make a release commit:
+`git add lib/landrush/version.rb CHANGELOG.md; git commit -m 'cut vX.Y.Z'`
+. Make a release tag: `git tag -m vX.Y.Z vX.Y.Z`
+. Push the release commit:
+`git push origin master; git push origin master --tags`
+. Build the release: `rake build`
+. Push the newly built gem: `gem push pkg/landrush-X.Y.Z.gem`
+. Update the CHANGELOG to add an "Unreleased" section, commit as
+"clean up after vX.Y.Z".
+
+== Maintainers
+
+* Brian Exelbierd (@bexelbie)
+* Eric Sorenson (@ahpook)
+* Florian Holzhauer (@fh)
+* Hardy Ferentschik (@hferentschik)
+* Josef Strzibny (@strzibny)
+* Paul Hinze (@phinze)
+* Reto Kaiser (@njam)

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,104 @@
+= Landrush: DNS for Vagrant
+:toc:
+:toc-placement!:
+
+
+https://travis-ci.org/vagrant-landrush/landrush[image:https://travis-ci.org/vagrant-landrush/landrush.png[Build
+Status]]
+https://ci.appveyor.com/project/hferentschik/landrush-3agrx/branch/master[image:https://ci.appveyor.com/api/projects/status/3iv8sv5v73s15mt6/branch/master?svg=true[Build
+status]]
+
+Landrush is a simple cross-platform DNS for Vagrant VMs that is visible
+on both, the guest and the host.
+
+It spins up a small DNS server and redirects DNS traffic from your VMs
+to use it, automatically registering/unregistering IP addresses of
+guests as they come up and go down.
+
+'''
+toc::[]
+'''
+
+== Installation
+
+Install under Vagrant (1.1 or later):
+
+....
+$ vagrant plugin install landrush
+....
+
+== Getting started
+
+.  Enable the plugin in your `Vagrantfile`:
++
+....
+config.landrush.enabled = true
+....
+.  Bring up a machine.
++
+....
+$ vagrant up
+....
+.  You are able to get your VM's hostname resolved on your host:
++
+....
+$ dig -p 10053 @localhost myhost.vagrant.test
+....
+.  If you shut down your guest, the entries associated with it will be
+removed.
+
+Landrush retrieves your VM's hostname from either the vagrant config or
+it uses the system's actual hostname by running the `hostname` command.
+A default hostname of "guest-vm" is assumed if the hostname is otherwise not
+available.
+
+A Landrush example configuration could look like this:
+
+....
+Vagrant.configure("2") do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  config.landrush.enabled = true
+
+  config.vm.hostname = "myhost.vagrant.test"
+
+  config.landrush.host 'static1.example.com', '1.2.3.4'
+  config.landrush.host 'static2.example.com', '2.3.4.5'
+end
+....
+
+See the link:Usage.adoc[Usage guide] for further information.
+
+== Available CLI commands
+
+Check out `vagrant landrush help` for the available commands.
+
+....
+vagrant landrush <command>
+
+commands:
+  {start|stop|restart|status}
+    control the landrush server daemon
+  list, ls
+    list all DNS entries known to landrush
+  dependentvms, vms
+    list vms currently dependent on the landrush server
+  set { <host> <ip> | <alias> <host> }
+    adds the given host-to-ip or alias-to-hostname mapping.
+    Existing host ip addresses will be overwritten
+  rm, del { <host> | <alias> | --all }
+    delete the given hostname or alias from the server.
+     --all removes all entries
+  help
+    you're lookin at it!
+....
+
+== Troubleshooting
+
+See the link:Troubleshooting.adoc[Troubleshooting guide] to resolve issues you face while using Landrush.
+
+== Help Out!
+
+This project could use your feedback and help! Please don't hesitate to
+open issues or submit pull requests. We welcome your input. +
+If you wish to contribute to the development of Landrush, refer to the link:CONTRIBUTING.adoc[Contributing guide] for details on how you can contribute. The link:Development.adoc[Development guide] will help you setup your development environment.

--- a/doc/Development.adoc
+++ b/doc/Development.adoc
@@ -1,0 +1,92 @@
+= Development
+:toc:
+:toc-placement!:
+
+The following should get you started on setting up your development environment. As a prerequisite you will need a Ruby 2.2 environment. We
+recommend to use https://rvm.io/[RVM] to create an isolated development
+environment. On Windows the http://rubyinstaller.org/[RubyInstaller for
+Windows] is probably the easiest way to get started. In this case you
+will need the http://rubyinstaller.org/add-ons/devkit/[DevKit] as well.
+
+'''
+toc::[]
+'''
+
+Once you have a working Ruby environment it is time to
+https://help.github.com/articles/fork-a-repo/[fork] the repository. Refer to the link:CONTRIBUTING.md[Contributing] guide for more information.
+
+The following sections list the most important commands you will need for
+development.
+
+== Setup
+
+* Install http://bundler.io/[Bundler]:
++
+....
+$ gem install bundler
+....
+* Install dependencies:
++
+....
+$ bundle install
+....
+* Get a list of all available build tasks:
++
+....
+$ bundle exec rake -T
+....
+
+* Build the Landrush gem:
++
+....
+$ bundle exec rake install
+....
+* Clean all generated files:
++
+....
+$ bundle exec rake clean clobber
+....
+
+== Tests
+
+* Run the test suite:
++
+....
+$ bundle exec rake test
+....
+* Run a single test file:
++
+....
+$ bundle exec rake test TEST=<path to test file>
+....
+* Run cucumber/aruba acceptance tests:
++
+....
+$ bundle exec rake features
+....
+
+NOTE: The acceptance tests currently work only for OS X, out of the box.
+On Linux, one has to manually configure the host visibility for the
+TLD _landrush-acceptance-test_. See *Linux* in the *Visibility on the Host* section of the link:Usage.adoc[Usage guide]. On Windows,
+the acceptance tests won't work due to a bug in
+https://github.com/cucumber/aruba/issues/387[Aruba].
+
+* Run a single cucumber/aruba acceptance tests:
++
+....
+$ bundle exec rake features FEATURE=features/<feature-filename>.feature
+....
+
+== Release
+
+* Deploy to RubyGems:
++
+....
+$ bundle exec rake release
+....
+* Run the vagrant binary with the Landrush plugin loaded from your local
+source code:
++
+....
+bundle exec vagrant landrush <command>
+....

--- a/doc/Troubleshooting.adoc
+++ b/doc/Troubleshooting.adoc
@@ -1,0 +1,43 @@
+= Troubleshooting
+
+:toc:
+:toc-placement!:
+
+Use this guide to resolve basic Landmark issues you run into.
+
+'''
+toc::[]
+'''
+
+== How to avoid providing sudo password on OS X
+
+When using Landrush on OS X, Landrush will try to create a file in
+`/etc/resolver` to make the guest VM visible via DNS on the host. See *OS X* in the *Visibility on the Host* section of the link:Usage.adoc[Usage guide]. To create this file, sudo permissions are needed and Landrush
+will ask you for your sudo password. +
+ +
+This can be avoided by adding the
+following entries to the bottom of the sudoer configuration. Make sure
+to edit your `/etc/sudoers` configuration via `sudo visudo`:
+
+....
+# Begin Landrush config
+Cmnd_Alias VAGRANT_LANDRUSH_HOST_MKDIR = /bin/mkdir /etc/resolver/*
+Cmnd_Alias VAGRANT_LANDRUSH_HOST_CP = /bin/cp /*/vagrant_landrush_host_config* /etc/resolver/*
+Cmnd_Alias VAGRANT_LANDRUSH_HOST_CHMOD = /bin/chmod 644 /etc/resolver/*
+%admin ALL=(ALL) NOPASSWD: VAGRANT_LANDRUSH_HOST_MKDIR, VAGRANT_LANDRUSH_HOST_CP, VAGRANT_LANDRUSH_HOST_CHMOD
+# End Landrush config
+....
+
+== Guest is unable to access the Internet
+
+In some network configurations the access to outside DNS servers is
+restricted (firewalls, VPN, etc). Since unmatched DNS queries are per
+default passed through to Google's DNS servers, this can lead to the
+fact that the guest cannot access anything in the outside world. +
+ +
+If you face problem with the guest's DNS, verify that you can access
+Google's DNS server under __8.8.8.8__. If it does not work, you will
+need to set a custom upstream DNS server. Check your network
+configuration on the host or ask your network administrator about the
+right DNS server address to use. You can set the custom DNS server via
+the `config.landrush.upstream` option, see section on *Unmatched Queries* in the link:Usage.adoc[Usage guide].

--- a/doc/Usage.adoc
+++ b/doc/Usage.adoc
@@ -1,0 +1,272 @@
+= Usage
+
+:toc:
+:toc-placement!:
+
+The following sections explain how you can use the Landrush DNS server and customize it as per your requirements, once you have link:README.adoc[installed] it.
+
+'''
+toc::[]
+'''
+
+== Dynamic entries
+
+Every time a VM is started, its IP address is automatically detected and
+a DNS record is created that maps the hostname to its IP. The detection
+works by listing all configured interfaces of the guest using
+https://rubygems.org/gems/landrush-ip/versions/0.2.5[landrush-ip],
+picking the last valid IP found, while ignoring any excluded interfaces.
+
+Excluded interfaces are an array of regular expressions; the value shown
+here is the default used when no explicit value for
+`config.landrush.host_interface_excludes` is specified in your
+`Vagrantfile`:
+
+....
+config.landrush.host_interface_excludes = [/lo[0-9]*/, /docker[0-9]+/, /tun[0-9]+/]
+....
+
+If Landrush fails to detect the correct IP address (or none at all), you
+can extend this exclusion range to exclude more interfaces.
+
+You can also make sure to only select a specific class of IP address
+(`:ipv4`, `:ipv6` or `:any`). Either way, empty values will not be
+returned, but in the case of `:any` you may get the IPv6 address for an
+interface that has no IPv4 address. The default is to return the first
+non-empty IPv4 address:
+
+....
+config.landrush.host_interface_class = :ipv4
+....
+
+If you need or want to select an interface explicitly and you know its
+name, you can also tell Landrush to grab that interface's IP address
+explicitly:
+
+....
+config.landrush.host_interface = 'eth0'
+....
+
+NOTE: If you specify an interface explicitly, it will have
+priority over `config.landrush.host_interface_excludes`. In other words,
+if `config.landrush.host_interface_excludes` is set to `[/eth[0-9]*/]`,
+but `config.landrush.host_interface` is set to `eth0` and `eth0` exists
+as an interface, the IP address of `eth0` is returned. The interface
+setting takes precedence over the exclude setting. If the interface does
+not exist, the regular heuristics will apply and Landrush will pick the
+last non-excluded IP found.
+
+If all else fails, you can override it entirely:
+
+....
+config.landrush.host_ip_address = '1.2.3.4'
+....
+
+This setting will override both the exclude and interface settings
+completely.
+
+If you are using a multi-machine `Vagrantfile`, configure this inside
+each of your `config.vm.define` sections.
+
+== Static entries
+
+You can add static host entries to the DNS server in your `Vagrantfile`
+like so:
+
+....
+config.landrush.host 'myhost.example.com', '1.2.3.4'
+....
+
+This is great for overriding production services for nodes you might be
+testing locally. For example, perhaps you might want to override the
+hostname of your puppetmaster to point to a local vagrant box instead.
+
+== Wildcard Subdomains
+
+For your convenience, any subdomain of a DNS entry known to Landrush
+will resolve to the same IP address as the entry. For example, given
+`myhost.vagrant.test -> 1.2.3.4`, both `foo.myhost.vagrant.test` and
+`bar.myhost.vagrant.test` will also resolve to `1.2.3.4`.
+
+If you would like to configure your guests to be accessible from the
+host as subdomains of something other than the default `vagrant.test`,
+you can use the `config.landrush.tld` option in your Vagrantfile like
+so:
+
+....
+config.landrush.tld = 'vm'
+....
+
+NOTE: From the **host**, you will only be able to access subdomains
+of your configured TLD by default, so wildcard subdomains only apply to
+that space. For the **guest**, wildcard subdomains work for anything.
+
+== Unmatched Queries
+
+Any DNS queries that do not match any of Landrush's configuration data,
+will be passed through to an upstream DNS server. Per default Landrush
+uses Google's DNS server with the IP __8.8.8.8__.
+
+If you would like to configure your own upstream servers, add upstream
+entries to your `Vagrantfile` like so:
+
+....
+config.landrush.upstream '10.1.1.10'
+# Set the port to 1001
+config.landrush.upstream '10.1.2.10', 1001
+# If your upstream is TCP only for some strange reason
+config.landrush.upstream '10.1.3.10', 1001, :tcp
+....
+
+== Visibility on the Guest
+
+Linux guests should automatically have their DNS traffic redirected via
+`iptables` rules to the Landrush DNS server. File an issue if this does
+not work for you.
+
+To disable this functionality:
+
+....
+config.landrush.guest_redirect_dns = false
+....
+
+You may want to do this if you are already proxying all your DNS
+requests through your host (for example, using VirtualBox's natdnshostresolver1
+option) and you have DNS servers that you can easily set as upstreams in
+the daemon (for example, DNS requests that go through the host's VPN
+connection).
+
+== Visibility on the Host
+
+Visibility on the host means that the hostname of the VMs can be
+resolved on the host's DNS system. Landrush will attempt an automatic
+configuration of the host, but depending on the OS, manual configuration
+might be required as well.
+
+To disable this functionality:
+
+....
+config.landrush.host_redirect_dns = false
+....
+
+* OS X
++
+If you are on an OS X host, we use a nice trick to unobtrusively add a
+secondary DNS server only for specific domains. During startup Landrush automatically adds
+a file into `/etc/resolver` that points
+lookups for hostnames ending in your `config.landrush.tld` domain to its
+DNS server. (See `man 5 resolver` on your Mac OS X host for more
+information on this file's syntax.)
+
+* Linux
++
+Landrush tries to achieve the same behavior on Linux hosts using
+`dnsmasq`. For some Linux distributions this happens automatically (you
+might have to provide your _sudo_ password). If Landrush does not know
+how to install and start `dnsmasq` on your favorite Linux distribution,
+you can adjust the following example from Ubuntu:
++
+....
+sudo apt-get install -y resolvconf dnsmasq
+sudo sh -c 'echo "server=/vagrant.test/127.0.0.1#10053" > /etc/dnsmasq.d/vagrant-landrush'
+sudo service dnsmasq restart
+....
++
+If you use a TLD other than the default `vagrant.test`, replace the TLD
+in the above instructions accordingly. Please be aware that anything
+ending in `.local` as TLD will not work because the `avahi` daemon
+reserves this TLD for its own uses.
+
+* Windows
++
+On Windows a secondary DNS server can be configured via the properties
+of the network adapter used by the VM. Landrush will attempt to
+configure the adapter automatically during startup. If this fails,
+please follow the manual setup instructions below.
++
+It is recommended to use an elevated command prompt (command prompt with
+full administrator permissions), since admin privileges are needed to
+make the required changes. Landrush will try to elevate your prompt
+automatically, but this requires spawning of additional processes which in
+turn loose some potentially important log messages.
++
+In the following section manual network configuration is described using
+Windows 10 and VirtualBox.
++
+When running VirtualBox on Windows in combination with Landrush the
+Network Connections
+(`Control Panel\Network and Internet\Network Connections`) looks
+somewhat like this after a successful `vagrant up`: +
+ +
++
+image:img/network-connections.png[Network
+Connections,title="Network Connections"] +
+ +
+There will be at least one VirtualBox network adapter. There might be
+multiple depending on your configuration (number of networks configured)
+and how many VMs you have running, but you just need to modify one.
++
+In a first step, you need to identify the VirtualBox network adapter used
+for the private network of your VM. Landrush requires a private network
+adapter to work and will create one in case you are not explicitly
+configuring one in your `Vagrantfile`.
++
+To quickly view the settings of each network adapter you can run the
+following command in a shell:
++
+....
+netsh interface ip show config
+....
++
+The output should look something like this:
++
+....
+Configuration for interface "Ethernet0"
+    DHCP enabled:                         Yes
+    IP Address:                           172.16.74.143
+    Subnet Prefix:                        172.16.74.0/24 (mask 255.255.255.0)
+    Default Gateway:                      172.16.74.2
+    Gateway Metric:                       0
+    InterfaceMetric:                      10
+    DNS servers configured through DHCP:  172.16.74.2
+    Register with which suffix:           Primary only
+    WINS servers configured through DHCP: 172.16.74.2
+
+Configuration for interface "VirtualBox Host-Only Network"
+    DHCP enabled:                         No
+    IP Address:                           10.1.2.1
+    Subnet Prefix:                        10.1.2.0/24 (mask 255.255.255.0)
+    InterfaceMetric:                      10
+    Statically Configured DNS Servers:    None
+    Register with which suffix:           Primary only
+    Statically Configured WINS Servers:   None
+....
++
+In our case we are interested in the `VirtualBox Host-Only Network`
+which has in this example the private network IP 10.1.2.1. If you do not
+have a static private network IP configured and you cannot determine the
+right adapter via the `netsh` output, ssh into the VM (`vagrant ssh`)
+and run `ifconfig` to view the network configuration of the VM.
++
+Once you identified the right network adapter run the following as
+Administrator (using the network adapter name of the adapter with the
+determined private network IP):
++
+....
+ netsh interface ipv4 add dnsserver "VirtualBox Host-Only Network" address=127.0.0.1 index=1
+....
++
+This should be enough for Windows 10. On other Windows versions, you
+might have to also add your TLD to the DNS suffix list on the DNS
+Advanced TCP/IP Settings tab: +
+ +
+image:img/advanced-tcp-properties.png[Advanced TCP/IP
+Settings,title="Advanced TCP/IP Settings"] +
+ +
+* Other Devices (phone)
++
+You might want to resolve Landrush's DNS-entries on _additional_
+computing devices, like a mobile phone.
+Please refer to link:/doc/proxy-mobile[mobile instructions] for further details.
+
+You can refer to the link:Troubleshooting.adoc[Troubleshooting guide] if you encounter any problems while using Landrush.


### PR DESCRIPTION
…Readme, Usage, Troubleshooting and Development, the last three are in the Docs folder.
This PR converts the existing markdown Readme and Contributing into Asciidoc Readme and Contributing. It also splits the doc into Readme, Usage, Troubleshooting and Development docs. The last three docs will reside in the docs folder of the repo. Interconnection between docs has been provided by interlinking the docs and a few additional lines providing the context. Minor language corrections have also been made.
