### PR TITLE
Fix method wired_autoconfig_service_running for windows

### DIFF
--- a/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
+++ b/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
@@ -146,8 +146,8 @@ module Landrush
           end
 
           def wired_autoconfig_service_running?
-            cmd_out = `net start`
-            cmd_out =~ /Wired AutoConfig/m
+            cmd_out = `sc query dot3svc`
+            cmd_out =~ /\s*STATE\s+:\s+4\s+RUNNING/m
           end
 
           def command_found(cmd)


### PR DESCRIPTION
Use locale independent variant to check if service dot3svc is running: sc query dot3svc
This fixes issue #310 