### PR TITLE
Change from OUTPUT to PREROUTING

### DIFF
--- a/lib/landrush/cap/guest/linux/redirect_dns.rb
+++ b/lib/landrush/cap/guest/linux/redirect_dns.rb
@@ -15,7 +15,7 @@ module Landrush
         end
 
         def self._redirect_dns_rule(protocol, original_server, target_server, target_port)
-          "OUTPUT -t nat -p #{protocol} -d #{original_server} --dport 53 -j DNAT --to-destination #{target_server}:#{target_port}"
+          "PREROUTING -t nat -p #{protocol} -d #{original_server} --dport 53 -j DNAT --to-destination #{target_server}:#{target_port}"
         end
       end
     end


### PR DESCRIPTION
I believe PREROUTING was the correct iptables stage to use, and a kernel change causes problems on eg 18.04 ubuntu.

Tested on older kernels, and is back-compatible.