### PR TITLE
Fix landrush not working if executed as admin

### DIFF
--- a/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
+++ b/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
@@ -45,7 +45,7 @@ module Landrush
               if_net = IPAddr.new("#{if_ip}/#{if_mask}")
               return interface_guid if if_net.include?(address)
             end
-            return nil
+            nil
           rescue StandardError
             nil
           end

--- a/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
+++ b/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
@@ -45,6 +45,7 @@ module Landrush
               if_net = IPAddr.new("#{if_ip}/#{if_mask}")
               return interface_guid if if_net.include?(address)
             end
+            return nil
           rescue StandardError
             nil
           end


### PR DESCRIPTION
## Issue
On Windows 10, running a `vagrant up` on an admin (power)shell crashes with `OpenKey': The system cannot find the file specified.` in update_network_adapter (as described [here](https://github.com/lukeelten/openshift-vagrant/issues/1))

## Cause
It seems that `get_network_guid` couldn't find the right network adapter while enumerating the registry (and indeed, no adapter has the required address, which might be caused by an underlying issue I've not explored).
In that special case, the return value is the size of the `interfaces` array (17 in my case), which makes `update_network_adapter`  try to open registry address 
`SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\17` and crash.

## Fix
Returning nil if the value couldn't be found in the adapters array, will fix the issue as `update_network_adapter` will then proceed to manual configuration and won't try to open an inexistent registry key.