### PR TITLE
Rename VMware Fusion support to VMware Desktop

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,9 @@ Install under Vagrant (1.1 or later):
 $ vagrant plugin install landrush
 ....
 
+If you're using the VMware provider, you'll need the
+link:https://www.vagrantup.com/vmware/index.html[Vagrant VMWare Desktop plugin].
+
 == Getting started
 
 .  Enable the plugin in your `Vagrantfile`:

--- a/lib/landrush/action/common.rb
+++ b/lib/landrush/action/common.rb
@@ -5,7 +5,7 @@ module Landrush
       SUPPORTED_PROVIDERS = {
         'VagrantPlugins::ProviderVirtualBox::Provider' => :virtualbox,
         'VagrantPlugins::ProviderLibvirt::Provider'    => :libvirt,
-        'HashiCorp::VagrantVMwarefusion::Provider'     => :vmware_fusion,
+        'HashiCorp::VagrantVMwareDesktop::Provider'    => :vmware_desktop,
         'VagrantPlugins::Parallels::Provider'          => :parallels,
         'VagrantPlugins::HyperV::Provider'             => :hyperv,
         'VagrantPlugins::DockerProvider::Provider'     => :docker,
@@ -34,7 +34,7 @@ module Landrush
       end
 
       def vmware?
-        provider == :vmware_fusion
+        provider == :vmware_desktop
       end
 
       def parallels?

--- a/lib/landrush/plugin.rb
+++ b/lib/landrush/plugin.rb
@@ -33,9 +33,9 @@ module Landrush
       end
 
       # Hooks for VMWarefusion provider
-      if defined?(HashiCorp::VagrantVMwarefusion)
-        hook.before(HashiCorp::VagrantVMwarefusion::Action::Network, pre_boot_actions)
-        hook.after(HashiCorp::VagrantVMwarefusion::Action::WaitForCommunicator, post_boot_actions)
+      if defined?(HashiCorp::VagrantVMwareDesktop)
+        hook.before(HashiCorp::VagrantVMwareDesktop::Action::Network, pre_boot_actions)
+        hook.after(HashiCorp::VagrantVMwareDesktop::Action::WaitForCommunicator, post_boot_actions)
       end
 
       # Hooks for Parallels provider


### PR DESCRIPTION
On 2016-03-26, HashiCorp released the VMware Desktop Plugin, which
replaced the existing VMware Fusion implementation. With the rename, the
hooks that Landrush needs to start services can no longer be called.
Renaming those makes those work again.

Fixes #334.