### PR TITLE
Update configure_visibility_on_host.rb

### DIFF
--- a/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
+++ b/lib/landrush/cap/host/windows/configure_visibility_on_host.rb
@@ -202,7 +202,7 @@ module Landrush
           end
 
           def wired_autoconfig_service_state
-            `sc query dot3svc`
+            `chcp 437 | sc query dot3svc`
           end
 
           def wired_autoconfig_service_running?


### PR DESCRIPTION
I suggest you add chcp 437 in windows command 'sc query dot3svc' to set its english output.
This change will fix cmd_out regex and will make it work on localized versions of windows.